### PR TITLE
Fix trailing whitespace (\) to simplify copying

### DIFF
--- a/_episodes/4.graphical.md
+++ b/_episodes/4.graphical.md
@@ -221,7 +221,7 @@ At the end, you'll also be able to re-run the phylogenetic tree script you execu
 > > $ export SINGULARITYENV_USER="$USER"
 > > $ singularity exec \
 > >     -B home_rstudio:/home/rstudio \
-> >     ggtree_2.0.4.sif \   
+> >     ggtree_2.0.4.sif \
 > >     rserver --www-port 8787 --www-address 0.0.0.0 --auth-none=0 --auth-pam-helper-path=pam-helper
 > > ```
 > > {: .bash}


### PR DESCRIPTION
There was trailing whitespace.